### PR TITLE
ENG-8: Create account registration endpoint and authentication functionality

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -7,7 +7,7 @@
                 "-i",
                 "--rm",
                 "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN",
+                "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_MCP_ACCESS_TOKEN}",
                 "-e",
                 "GITHUB_TOOLSETS=repos,pull_requests",
                 "-e",
@@ -15,10 +15,7 @@
                 "-e",
                 "GITHUB_READ_ONLY=0",
                 "ghcr.io/github/github-mcp-server"
-            ],
-            "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_ACCESS_TOKEN}"
-            }
+            ]
         }
     }
 }

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,24 @@
+{
+    "mcpServers": {
+        "github": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "GITHUB_PERSONAL_ACCESS_TOKEN",
+                "-e",
+                "GITHUB_TOOLSETS=repos,pull_requests",
+                "-e",
+                "GITHUB_DYNAMIC_TOOLSETS=1",
+                "-e",
+                "GITHUB_READ_ONLY=0",
+                "ghcr.io/github/github-mcp-server"
+            ],
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_ACCESS_TOKEN}"
+            }
+        }
+    }
+}

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -7,7 +7,7 @@
                 "-i",
                 "--rm",
                 "-e",
-                "GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_MCP_ACCESS_TOKEN}",
+                "GITHUB_PERSONAL_ACCESS_TOKEN",
                 "-e",
                 "GITHUB_TOOLSETS=repos,pull_requests",
                 "-e",
@@ -15,7 +15,10 @@
                 "-e",
                 "GITHUB_READ_ONLY=0",
                 "ghcr.io/github/github-mcp-server"
-            ]
+            ],
+            "env": {
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_ACCESS_TOKEN}"
+            }
         }
     }
 }

--- a/.cursor/rules/laravel-testing-standards.mdc
+++ b/.cursor/rules/laravel-testing-standards.mdc
@@ -1,0 +1,339 @@
+---
+description:
+globs: tests/**/*Test.php
+alwaysApply: false
+---
+# Laravel Testing Standards
+
+## Test Structure and Organization
+
+### AAA Pattern (Arrange-Act-Assert)
+All tests must follow the Arrange-Act-Assert pattern with clear comments:
+
+```php
+test('descriptive test name', function () {
+    // Arrange
+    $faker = Factory::create();
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => $faker->password(8, 20),
+    ];
+
+    // Act
+    $response = $this->postJson('/api/endpoint', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_CREATED)
+        ->assertJsonStructure(['expected', 'structure']);
+});
+```
+
+### Test Naming Convention
+- Use descriptive, behavior-focused names
+- Format: `test('should do something when condition', function () {})`
+- Examples:
+  - `test('user can register with valid data', function () {})`
+  - `test('registration fails with invalid email', function () {})`
+  - `test('should return 404 when resource not found', function () {})`
+
+## Test Data Management
+
+### Use Faker for All Test Data
+Never use hardcoded values. Always use Faker for realistic test data:
+
+```php
+// ✅ Good
+$faker = Factory::create();
+$userData = [
+    'name' => $faker->name(),
+    'email' => $faker->unique()->safeEmail(),
+    'password' => $faker->password(8, 20),
+];
+
+// ❌ Bad
+$userData = [
+    'name' => 'John Doe',
+    'email' => 'john@example.com',
+    'password' => 'password123',
+];
+```
+
+### Faker Best Practices
+- Use `unique()` for emails to prevent conflicts
+- Use `safeEmail()` for valid email formats
+- Use `password(min, max)` for realistic passwords
+- Use `name()` for realistic names
+- Use `text()` for content fields
+- Use `dateTime()` for timestamps
+
+## HTTP Status Codes
+
+### Use Constants, Not Magic Numbers
+Always use Laravel's HTTP status code constants:
+
+```php
+// ✅ Good
+use Symfony\Component\HttpFoundation\Response;
+
+$response->assertStatus(Response::HTTP_CREATED);
+$response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+$response->assertStatus(Response::HTTP_NOT_FOUND);
+
+// ❌ Bad
+$response->assertStatus(201);
+$response->assertStatus(422);
+$response->assertStatus(404);
+```
+
+### Common HTTP Status Constants
+- `Response::HTTP_OK` (200)
+- `Response::HTTP_CREATED` (201)
+- `Response::HTTP_NO_CONTENT` (204)
+- `Response::HTTP_BAD_REQUEST` (400)
+- `Response::HTTP_UNAUTHORIZED` (401)
+- `Response::HTTP_FORBIDDEN` (403)
+- `Response::HTTP_NOT_FOUND` (404)
+- `Response::HTTP_UNPROCESSABLE_ENTITY` (422)
+- `Response::HTTP_INTERNAL_SERVER_ERROR` (500)
+
+## Test Organization
+
+### File Structure
+```
+tests/
+├── Feature/
+│   ├── Auth/
+│   │   ├── RegistrationTest.php
+│   │   ├── LoginTest.php
+│   │   └── PasswordResetTest.php
+│   └── Api/
+│       ├── UserTest.php
+│       └── ResourceTest.php
+└── Unit/
+    └── ModelTest.php
+```
+
+### Test Class Structure
+```php
+<?php
+
+use App\Models\User;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Setup common test data or OAuth clients
+});
+
+test('test name', function () {
+    // Arrange
+    // Act
+    // Assert
+});
+```
+
+## Assertions and Validations
+
+### Response Assertions
+```php
+// Status and structure
+$response->assertStatus(Response::HTTP_CREATED)
+    ->assertJsonStructure([
+        'message',
+        'data' => [
+            'id',
+            'name',
+            'email',
+        ],
+    ]);
+
+// Content validation
+$response->assertJson([
+    'message' => 'Success message',
+    'data' => [
+        'name' => $userData['name'],
+        'email' => $userData['email'],
+    ],
+]);
+
+// Validation errors
+$response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+    ->assertJsonValidationErrors(['email', 'password']);
+```
+
+### Database Assertions
+```php
+// Check record exists
+$this->assertDatabaseHas('users', [
+    'email' => $userData['email'],
+    'name' => $userData['name'],
+]);
+
+// Check record doesn't exist
+$this->assertDatabaseMissing('users', [
+    'email' => 'deleted@example.com',
+]);
+
+// Check count
+$this->assertDatabaseCount('users', 1);
+```
+
+## Authentication and Authorization
+
+### OAuth Client Setup (for Passport)
+```php
+beforeEach(function () {
+    Client::create([
+        'id' => 'personal-access-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Personal Access Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['personal_access'],
+        'revoked' => false,
+    ]);
+});
+```
+
+### Authentication Tests
+```php
+test('authenticated user can access protected endpoint', function () {
+    // Arrange
+    $user = User::factory()->create();
+    $token = $user->createToken('test-token')->accessToken;
+
+    // Act
+    $response = $this->withHeaders([
+        'Authorization' => 'Bearer ' . $token,
+    ])->getJson('/api/protected-endpoint');
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK);
+});
+```
+
+## Error Handling
+
+### Exception Testing
+```php
+test('should handle database errors gracefully', function () {
+    // Arrange
+    $faker = Factory::create();
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => $faker->password(8, 20),
+    ];
+
+    // Mock database failure
+    User::shouldReceive('create')->andThrow(new \Exception('Database error'));
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR)
+        ->assertJson([
+            'message' => 'An error occurred while creating the user.',
+        ]);
+});
+```
+
+## Performance and Best Practices
+
+### Test Isolation
+- Use `RefreshDatabase` trait for feature tests
+- Use `DatabaseTransactions` for unit tests
+- Never rely on test execution order
+- Clean up after each test
+
+### Test Data Cleanup
+```php
+afterEach(function () {
+    // Clean up any test-specific data
+    User::where('email', 'like', '%@test.com')->delete();
+});
+```
+
+### Avoid Test Interference
+- Use `unique()` for emails and other unique fields
+- Use different data for each test
+- Don't share state between tests
+
+## Code Quality
+
+### Imports and Dependencies
+```php
+// Always import these for feature tests
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpFoundation\Response;
+
+// Import models and classes being tested
+use App\Models\User;
+use App\Http\Controllers\AuthController;
+```
+
+### Comments and Documentation
+- Use clear, descriptive comments in the Arrange section
+- Explain complex test scenarios
+- Document any test-specific setup or mocking
+
+### Consistent Formatting
+- Use consistent indentation (4 spaces)
+- Group related assertions together
+- Use method chaining for related assertions
+- Keep test methods focused and single-purpose
+
+## Example Complete Test
+```php
+test('user can register with valid data and receive access token', function () {
+    // Arrange
+    $faker = Factory::create();
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => $faker->password(8, 20),
+        'password_confirmation' => null,
+    ];
+    $userData['password_confirmation'] = $userData['password'];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_CREATED)
+        ->assertJsonStructure([
+            'message',
+            'user' => [
+                'id',
+                'name',
+                'email',
+                'created_at',
+            ],
+            'access_token',
+            'token_type',
+        ])
+        ->assertJson([
+            'message' => 'User registered successfully.',
+            'user' => [
+                'name' => $userData['name'],
+                'email' => $userData['email'],
+            ],
+            'token_type' => 'Bearer',
+        ]);
+
+    $this->assertDatabaseHas('users', [
+        'name' => $userData['name'],
+        'email' => $userData['email'],
+    ]);
+
+    $this->assertNotEmpty($response->json('access_token'));
+});
+```

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthController extends Controller
+{
+    /**
+     * Register a new user.
+     */
+    public function register(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ], [
+            'email.unique' => 'An account with this email address already exists.',
+            'password.confirmed' => 'Password confirmation does not match.',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        try {
+            $user = User::create([
+                'name' => $request->name,
+                'email' => $request->email,
+                'password' => Hash::make($request->password),
+            ]);
+
+            // Generate access token for the new user
+            $token = $user->createToken('auth-token')->accessToken;
+
+            return response()->json([
+                'message' => 'User registered successfully.',
+                'user' => [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'email' => $user->email,
+                    'created_at' => $user->created_at,
+                ],
+                'access_token' => $token,
+                'token_type' => 'Bearer',
+            ], Response::HTTP_CREATED);
+        } catch (Exception $e) {
+            return response()->json([
+                'message' => 'An error occurred while creating the user.',
+                'error' => config('app.debug') ? $e->getMessage() : 'Internal server error.',
+            ], Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,7 @@
     "ignorePaths": [
         ".vscode",
         ".env.*",
+        ".cursor/**/*.json",
         "node_modules",
         "vendor",
         "storage/framework/views",

--- a/cspell.json
+++ b/cspell.json
@@ -18,7 +18,8 @@
         "roundrobin",
         "sasl",
         "shivammathur",
-        "sslmode"
+        "sslmode",
+        "Symfony"
     ],
     "ignorePaths": [
         ".vscode",

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,13 +1,19 @@
 <?php
 
+use App\Http\Controllers\AuthController;
 use App\Http\Controllers\GoalsController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
-Route::get('user', function (Request $request) {
-    return $request->user();
-})->middleware('auth:api');
+// Authentication routes (no middleware required)
+Route::post('auth/register', [AuthController::class, 'register']);
 
-Route::get('goals/active', [GoalsController::class, 'getActiveGoals'])->middleware('auth:api');
+// Protected routes (require authentication)
+Route::middleware('auth:api')->group(function () {
+    Route::get('user', function (Request $request) {
+        return $request->user();
+    });
 
-Route::patch('goals/{id}', [GoalsController::class, 'update'])->middleware('auth:api');
+    Route::get('goals/active', [GoalsController::class, 'getActiveGoals']);
+    Route::patch('goals/{id}', [GoalsController::class, 'update']);
+});

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use App\Models\User;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Client;
+use Symfony\Component\HttpFoundation\Response;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Create OAuth clients for Passport
+    Client::create([
+        'id' => 'personal-access-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Personal Access Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['personal_access'],
+        'revoked' => false,
+    ]);
+
+    Client::create([
+        'id' => 'password-grant-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Password Grant Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['password'],
+        'revoked' => false,
+    ]);
+});
+
+test('user can register with valid data', function () {
+    // Arrange
+    $faker = Factory::create();
+
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => $faker->password(8, 20),
+        'password_confirmation' => null,
+    ];
+    $userData['password_confirmation'] = $userData['password'];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_CREATED)
+        ->assertJsonStructure([
+            'message',
+            'user' => [
+                'id',
+                'name',
+                'email',
+                'created_at',
+            ],
+            'access_token',
+            'token_type',
+        ])
+        ->assertJson([
+            'message' => 'User registered successfully.',
+            'user' => [
+                'name' => $userData['name'],
+                'email' => $userData['email'],
+            ],
+            'token_type' => 'Bearer',
+        ]);
+
+    $this->assertDatabaseHas('users', [
+        'name' => $userData['name'],
+        'email' => $userData['email'],
+    ]);
+
+    $this->assertNotEmpty($response->json('access_token'));
+});
+
+test('registration fails with invalid email', function () {
+    // Arrange
+    $faker = Factory::create();
+
+    $userData = [
+        'name' => $faker->name(),
+        'email' => 'invalid-email',
+        'password' => $faker->password(8, 20),
+        'password_confirmation' => null,
+    ];
+    $userData['password_confirmation'] = $userData['password'];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email']);
+});
+
+test('registration fails with duplicate email', function () {
+    // Arrange
+    $faker = Factory::create();
+    $email = $faker->unique()->safeEmail();
+
+    User::factory()->create(['email' => $email]);
+
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $email,
+        'password' => $faker->password(8, 20),
+        'password_confirmation' => null,
+    ];
+    $userData['password_confirmation'] = $userData['password'];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email'])
+        ->assertJson([
+            'errors' => [
+                'email' => ['An account with this email address already exists.'],
+            ],
+        ]);
+});
+
+test('registration fails with mismatched passwords', function () {
+    // Arrange
+    $faker = Factory::create();
+
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => $faker->password(8, 20),
+        'password_confirmation' => $faker->password(8, 20),
+    ];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['password'])
+        ->assertJson([
+            'errors' => [
+                'password' => ['Password confirmation does not match.'],
+            ],
+        ]);
+});
+
+test('registration fails with weak password', function () {
+    // Arrange
+    $faker = Factory::create();
+
+    $userData = [
+        'name' => $faker->name(),
+        'email' => $faker->unique()->safeEmail(),
+        'password' => '123',
+        'password_confirmation' => '123',
+    ];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['password']);
+});
+
+test('registration fails with missing required fields', function () {
+    // Arrange
+    $userData = [];
+
+    // Act
+    $response = $this->postJson('/api/auth/register', $userData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['name', 'email', 'password']);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,13 +6,13 @@
 |--------------------------------------------------------------------------
 |
 | The closure you provide to your test functions is always bound to a specific PHPUnit test
-| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| case class. By default, that class is "PHPUnit\\Framework\\TestCase". Of course, you may
 | need to change it using the "pest()" function to bind a different classes or traits.
 |
 */
 
 pest()->extend(Tests\TestCase::class)
- // ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
     ->in('Feature');
 
 /*


### PR DESCRIPTION
## Summary
Implements user registration endpoint for the Goal Digger API as part of ticket [ENG-8](https://mtpultz.atlassian.net/browse/ENG-8).

## Changes Made

### New Registration Endpoint
- **POST** `/api/auth/register` - Register new user account with validation

### Features
- Comprehensive input validation (name, email, password with confirmation)
- Email uniqueness validation with custom error messages
- Automatic access token generation upon successful registration
- Strong password validation using Laravel's Password rules
- Proper exception handling and error responses

### Testing
- Complete test suite covering valid registration and validation failures
- Tests for invalid email, duplicate email, weak password, and missing fields

## API Response Examples

### Success
```json
{
  "message": "User registered successfully.",
  "user": { "id": 1, "name": "John Doe", "email": "john@example.com" },
  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9...",
  "token_type": "Bearer"
}
```

### Validation Error
```json
{
  "message": "Validation failed.",
  "errors": { "email": ["An account with this email address already exists."] }
}
```

## Testing Instructions
Run: `php artisan test tests/Feature/Auth/RegistrationTest.php`

## Breaking Changes
None - all new functionality is additive.

## Dependencies
No new dependencies added.

## Related Issues
Closes [ENG-8](https://mtpultz.atlassian.net/browse/ENG-8)


[ENG-8]: https://mtpultz.atlassian.net/browse/ENG-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENG-8]: https://mtpultz.atlassian.net/browse/ENG-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ