### PR TITLE
Add login endpoint for user authentication (ENG-9)

### DIFF
--- a/.cursor/mcp.template.json
+++ b/.cursor/mcp.template.json
@@ -17,7 +17,7 @@
                 "ghcr.io/github/github-mcp-server"
             ],
             "env": {
-                "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_MCP_ACCESS_TOKEN}"
+                "GITHUB_PERSONAL_ACCESS_TOKEN": "__TOKEN__"
             }
         }
     }

--- a/.cursor/rules/pr-format.mdc
+++ b/.cursor/rules/pr-format.mdc
@@ -1,0 +1,5 @@
+---
+description:
+globs:
+alwaysApply: false
+---

--- a/.cursor/rules/pr-format.mdc
+++ b/.cursor/rules/pr-format.mdc
@@ -1,5 +1,62 @@
 ---
-description:
+description: Apply this rule when creating a PR
 globs:
 alwaysApply: false
 ---
+# Pull Request Format Standard
+
+All pull requests must follow this format for clarity, consistency, and ease of review.
+
+## Summary
+Briefly describe what the PR implements and reference the relevant Jira ticket (e.g., [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).
+
+## Changes Made
+
+### New Endpoint/Feature
+- **METHOD** `/api/endpoint` – Short description of the endpoint or feature
+
+### Features
+- List key features, validations, and behaviors
+- Mention any security or error handling improvements
+
+### Testing
+- List the types of tests added and what scenarios they cover
+
+## API Response Examples
+
+### Success
+```json
+{
+  "message": "...",
+  "user": { "id": 1, "name": "John Doe", "email": "john@example.com" },
+  "access_token": "...",
+  "token_type": "Bearer"
+}
+```
+
+### Validation Error
+```json
+{
+  "message": "Validation failed.",
+  "errors": { "field": ["Error message."] }
+}
+```
+
+### Other Errors (if applicable)
+```json
+{
+  "message": "Error message."
+}
+```
+
+## Testing Instructions
+Describe how to run the tests for this PR (e.g., `php artisan test tests/Feature/Auth/EndpointTest.php`).
+
+## Breaking Changes
+State if there are any breaking changes. If none, write "None – all new functionality is additive."
+
+## Dependencies
+List any new dependencies. If none, write "No new dependencies added."
+
+## Related Issues
+Reference the Jira ticket(s) this PR closes (e.g., Closes [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,2 @@
+# Ignore project-level MCP configuration that may contain sensitive tokens
+.cursor/mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Homestead.yaml
 Thumbs.db
 goal_digger
 .rnd
+
+# Generated files for Cursor setup
+.cursor/mcp.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Goal Digger
 
-A goal tracker for those chasing goals like they’re rich, shiny, and mildly afraid of commitment.
+A goal tracker for those chasing goals like they're rich, shiny, and mildly afraid of commitment.
 
 ## Table of Contents
 
@@ -46,6 +46,7 @@ A goal tracker for those chasing goals like they’re rich, shiny, and mildly af
 -   Run `php artisan db:seed` to add seed data to the database
 -   Run `composer run dev` to start the application, and
 -   Visit `http://goal-digger.test`
+-   Run `npm run setup:mcp` to create the `.cursor/mcp.json` file for Cursor MCP integrations
 
 ## Using Access Tokens
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ A goal tracker for those chasing goals like they're rich, shiny, and mildly afra
 -   Run `php artisan db:seed` to add seed data to the database
 -   Run `composer run dev` to start the application, and
 -   Visit `http://goal-digger.test`
--   Run `npm run setup:mcp` to create the `.cursor/mcp.json` file for Cursor MCP integrations, which assumes you have a `GITHUB_MCP_ACCESS_TOKEN` environment variable set.
+-   Run `npm run setup:mcp` to create the `.cursor/mcp.json` file for Cursor MCP integrations
+    -   Assumes you have a `fine grained access token` set in an environment variable named `GITHUB_MCP_ACCESS_TOKEN` set with repository permissions of `content`, `pull requests`, and `issues`
 
 ## Using Access Tokens
 

--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ A goal tracker for those chasing goals like they're rich, shiny, and mildly afra
     }
     ```
 
--   Make a request to `POST {{BASE_URL}}/api/register`, which should insert a new user into the `Users` table
+-   Make a request to `POST {{BASE_URL}}/auth/register`, which should insert a new user into the `Users` table

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A goal tracker for those chasing goals like they're rich, shiny, and mildly afra
 -   Run `php artisan db:seed` to add seed data to the database
 -   Run `composer run dev` to start the application, and
 -   Visit `http://goal-digger.test`
--   Run `npm run setup:mcp` to create the `.cursor/mcp.json` file for Cursor MCP integrations
+-   Run `npm run setup:mcp` to create the `.cursor/mcp.json` file for Cursor MCP integrations, which assumes you have a `GITHUB_MCP_ACCESS_TOKEN` environment variable set.
 
 ## Using Access Tokens
 

--- a/cspell.json
+++ b/cspell.json
@@ -19,8 +19,7 @@
         "sasl",
         "shivammathur",
         "sslmode",
-        "Symfony",
-        "mtpultz"
+        "Symfony"
     ],
     "ignorePaths": [
         ".vscode",

--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
         "sasl",
         "shivammathur",
         "sslmode",
-        "Symfony"
+        "Symfony",
+        "mtpultz"
     ],
     "ignorePaths": [
         ".vscode",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "lint:fix": "eslint . --fix",
         "spell:check": "cspell \"./**/*.*\" --words-only --unique --gitignore",
         "spell:check:errors": "cspell \"./**/*.*\" --words-only --unique --gitignore --quiet",
-        "prepare": "husky"
+        "prepare": "husky",
+        "setup:mcp": "bash scripts/setup-mcp.sh"
     },
     "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Route;
 
 // Authentication routes (no middleware required)
 Route::post('auth/register', [AuthController::class, 'register']);
+Route::post('auth/login', [AuthController::class, 'login']);
 
 // Protected routes (require authentication)
 Route::middleware('auth:api')->group(function () {

--- a/scripts/setup-mcp.sh
+++ b/scripts/setup-mcp.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+TEMPLATE_FILE=".cursor/mcp.template.json"
+TARGET_FILE=".cursor/mcp.json"
+
+if [ -z "$GITHUB_MCP_ACCESS_TOKEN" ]; then
+  echo "❌ GITHUB_MCP_ACCESS_TOKEN is not set."
+  echo "Set it using: export GITHUB_MCP_ACCESS_TOKEN=github_pat_..."
+  exit 1
+fi
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+  echo "❌ Missing template file: $TEMPLATE_FILE"
+  exit 1
+fi
+
+# Make the .cursor directory if it doesn't exist
+mkdir -p .cursor
+
+# Replace the token placeholder with the actual token
+sed "s|__TOKEN__|${GITHUB_MCP_ACCESS_TOKEN}|" "$TEMPLATE_FILE" > "$TARGET_FILE"
+
+echo "✅ Generated: $TARGET_FILE"

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\User;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Client;
+use Symfony\Component\HttpFoundation\Response;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Create OAuth clients for Passport
+    Client::create([
+        'id' => 'personal-access-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Personal Access Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['personal_access'],
+        'revoked' => false,
+    ]);
+
+    Client::create([
+        'id' => 'password-grant-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Password Grant Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['password'],
+        'revoked' => false,
+    ]);
+});
+
+test('user can login with valid credentials', function () {
+    // Arrange
+    $faker = Factory::create();
+    $password = $faker->password(8, 20);
+    $user = User::factory()->create([
+        'email' => $faker->unique()->safeEmail(),
+        'password' => bcrypt($password),
+    ]);
+
+    $loginData = [
+        'email' => $user->email,
+        'password' => $password,
+    ];
+
+    // Act
+    $response = $this->postJson('/api/auth/login', $loginData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJsonStructure([
+            'message',
+            'user' => [
+                'id',
+                'name',
+                'email',
+                'created_at',
+            ],
+            'access_token',
+            'token_type',
+        ])
+        ->assertJson([
+            'message' => 'Login successful.',
+            'user' => [
+                'email' => $user->email,
+            ],
+            'token_type' => 'Bearer',
+        ]);
+
+    $this->assertNotEmpty($response->json('access_token'));
+});
+
+test('login fails with invalid credentials', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create([
+        'email' => $faker->unique()->safeEmail(),
+        'password' => bcrypt('correct-password'),
+    ]);
+
+    $loginData = [
+        'email' => $user->email,
+        'password' => 'wrong-password',
+    ];
+
+    // Act
+    $response = $this->postJson('/api/auth/login', $loginData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNAUTHORIZED)
+        ->assertJson([
+            'message' => 'Invalid credentials.',
+        ]);
+});
+
+test('login fails with missing required fields', function () {
+    // Arrange
+    $loginData = [];
+
+    // Act
+    $response = $this->postJson('/api/auth/login', $loginData);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email', 'password']);
+});


### PR DESCRIPTION
## Summary
Implements user login endpoint for the Goal Digger API as part of ticket [ENG-9](https://mtpultz.atlassian.net/browse/ENG-9).

## Changes Made

### New Login Endpoint
- **POST** `/api/auth/login` – Authenticate user with email and password

### Features
- Input validation for email and password
- Credential verification with appropriate error responses
- Automatic access token generation upon successful login
- Returns user details and token on success
- Adds `.cursorignore` to exclude `.cursor/mcp.json` from scanning (protects API tokens)
- Adds a Cursor rule for PR format standardization

### Testing
- Complete test suite covering valid login and validation failures
- Tests for invalid credentials and missing fields

## API Response Examples

### Success
```json
{
  "message": "Login successful.",
  "user": { "id": 1, "name": "John Doe", "email": "john@example.com", "created_at": "2024-06-18T12:34:56.000000Z" },
  "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9...",
  "token_type": "Bearer"
}
```

### Validation Error
```json
{
  "message": "Validation failed.",
  "errors": { "email": ["The email field is required."], "password": ["The password field is required."] }
}
```

### Invalid Credentials
```json
{
  "message": "Invalid credentials."
}
```

## Testing Instructions
Run: `php artisan test tests/Feature/Auth/LoginTest.php`

## Breaking Changes
None – all new functionality is additive.

## Dependencies
No new dependencies added.

## Related Issues
Closes [ENG-9](https://mtpultz.atlassian.net/browse/ENG-9)

[ENG-9]: https://mtpultz.atlassian.net/browse/ENG-9
