### PR TITLE
ENG-10: Implement forgot password and email verification endpoints

### DIFF
--- a/.cursor/rules/pr-process.mdc
+++ b/.cursor/rules/pr-process.mdc
@@ -13,7 +13,7 @@ All pull requests must follow this process for clarity, consistency, and ease of
 ## PR Format
 
 ### Summary
-Briefly describe what the PR implements and reference the relevant Jira ticket (e.g., [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).
+Briefly describe what the PR implements and reference the relevant Jira ticket (e.g., [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)) as a clickable link.
 
 ### Changes
 
@@ -64,7 +64,7 @@ State if there are any breaking changes. If none, write "None – all new functi
 List any new dependencies. If none, write "No new dependencies added."
 
 ### Related Issues
-Reference the Jira ticket(s) this PR closes (e.g., Closes [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).
+Reference the Jira ticket(s) this PR closes (e.g., Closes [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)) as clickable links.
 
 ## Post-PR Requirement
 - **Always provide a link to the created PR** after it is committed.

--- a/.cursor/rules/pr-process.mdc
+++ b/.cursor/rules/pr-process.mdc
@@ -3,28 +3,33 @@ description: Apply this rule when creating a PR
 globs:
 alwaysApply: false
 ---
-# Pull Request Format Standard
+# Pull Request Process Standard
 
-All pull requests must follow this format for clarity, consistency, and ease of review.
+All pull requests must follow this process for clarity, consistency, and ease of review.
 
-## Summary
+## Pre-PR Requirements
+- **Run all associated tests** for the changes before creating the PR. The PR should only be created if all tests pass.
+
+## PR Format
+
+### Summary
 Briefly describe what the PR implements and reference the relevant Jira ticket (e.g., [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).
 
-## Changes Made
+### Changes
 
-### New Endpoint/Feature
+#### New Endpoint/Feature
 - **METHOD** `/api/endpoint` – Short description of the endpoint or feature
 
-### Features
+#### Features
 - List key features, validations, and behaviors
 - Mention any security or error handling improvements
 
-### Testing
+#### Testing
 - List the types of tests added and what scenarios they cover
 
-## API Response Examples
+### API Response Examples
 
-### Success
+#### Success
 ```json
 {
   "message": "...",
@@ -34,7 +39,7 @@ Briefly describe what the PR implements and reference the relevant Jira ticket (
 }
 ```
 
-### Validation Error
+#### Validation Error
 ```json
 {
   "message": "Validation failed.",
@@ -42,21 +47,24 @@ Briefly describe what the PR implements and reference the relevant Jira ticket (
 }
 ```
 
-### Other Errors (if applicable)
+#### Other Errors (if applicable)
 ```json
 {
   "message": "Error message."
 }
 ```
 
-## Testing Instructions
+### Testing Instructions
 Describe how to run the tests for this PR (e.g., `php artisan test tests/Feature/Auth/EndpointTest.php`).
 
-## Breaking Changes
+### Breaking Changes
 State if there are any breaking changes. If none, write "None – all new functionality is additive."
 
-## Dependencies
+### Dependencies
 List any new dependencies. If none, write "No new dependencies added."
 
-## Related Issues
+### Related Issues
 Reference the Jira ticket(s) this PR closes (e.g., Closes [ENG-9](mdc:https:/<your-org>.atlassian.net/browse/ENG-9)).
+
+## Post-PR Requirement
+- **Always provide a link to the created PR** after it is committed.

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,6 +7,7 @@ use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password as PasswordFacade;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
 use Symfony\Component\HttpFoundation\Response;
@@ -101,6 +102,132 @@ class AuthController extends Controller
             ],
             'access_token' => $token,
             'token_type' => 'Bearer',
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * Send a password reset link to the given email.
+     */
+    public function forgotPassword(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'email', 'exists:users,email'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        $status = PasswordFacade::sendResetLink($request->only('email'));
+        if ($status === PasswordFacade::RESET_LINK_SENT) {
+            return response()->json([
+                'message' => 'Password reset link sent.',
+            ], Response::HTTP_OK);
+        }
+
+        return response()->json([
+            'message' => 'Unable to send password reset link.',
+        ], Response::HTTP_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Reset the user's password.
+     */
+    public function resetPassword(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'email', 'exists:users,email'],
+            'token' => ['required', 'string'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        $status = PasswordFacade::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user, $password) {
+                $user->forceFill([
+                    'password' => Hash::make($password),
+                ])->save();
+            }
+        );
+        if ($status === PasswordFacade::PASSWORD_RESET) {
+            return response()->json([
+                'message' => 'Password has been reset.',
+            ], Response::HTTP_OK);
+        }
+
+        return response()->json([
+            'message' => 'Invalid token or email.',
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
+     * Verify the user's email address.
+     */
+    public function verifyEmail(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'id' => ['required', 'integer', 'exists:users,id'],
+            'hash' => ['required', 'string'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        $user = User::find($request->id);
+        if (! $user || ! hash_equals(sha1($user->getEmailForVerification()), $request->hash)) {
+            return response()->json([
+                'message' => 'Invalid verification link.',
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        if ($user->hasVerifiedEmail()) {
+            return response()->json([
+                'message' => 'Email already verified.',
+            ], Response::HTTP_OK);
+        }
+        $user->markEmailAsVerified();
+
+        return response()->json([
+            'message' => 'Email verified successfully.',
+        ], Response::HTTP_OK);
+    }
+
+    /**
+     * Resend the email verification notification.
+     */
+    public function resendVerification(Request $request): JsonResponse
+    {
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'email', 'exists:users,email'],
+        ]);
+        if ($validator->fails()) {
+            return response()->json([
+                'message' => 'Validation failed.',
+                'errors' => $validator->errors(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+        $user = User::where('email', $request->email)->first();
+        if (! $user) {
+            return response()->json([
+                'message' => 'User not found.',
+            ], Response::HTTP_NOT_FOUND);
+        }
+        if ($user->hasVerifiedEmail()) {
+            return response()->json([
+                'message' => 'Email already verified.',
+            ], Response::HTTP_OK);
+        }
+        $user->sendEmailVerificationNotification();
+
+        return response()->json([
+            'message' => 'Verification email resent.',
         ], Response::HTTP_OK);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,7 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Notifications\ResetPasswordNotification;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -106,6 +106,14 @@ class User extends Authenticatable implements OAuthenticatable
         return $this->hasMany(Buddy::class, 'buddy_id')
             ->where('status', 'PENDING')
             ->with('user');
+    }
+
+    /**
+     * Send the password reset notification.
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new ResetPasswordNotification($token));
     }
 
     /**

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Auth\Notifications\ResetPassword as BaseResetPassword;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPasswordNotification extends BaseResetPassword
+{
+    /**
+     * Get the reset password notification mail message for the given URL.
+     */
+    public function toMail($notifiable)
+    {
+        $frontendUrl = config('app.frontend_url', 'http://localhost:3000') . '/reset-password?token=' . $this->token . '&email=' . urlencode($notifiable->getEmailForPasswordReset());
+
+        return (new MailMessage)
+            ->subject('Reset Password Notification')
+            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->action('Reset Password', $frontendUrl)
+            ->line('If you did not request a password reset, no further action is required.');
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,7 +8,11 @@ use Illuminate\Support\Facades\Route;
 
 // Authentication routes (no middleware required)
 Route::post('auth/register', [AuthController::class, 'register']);
+Route::post('auth/verify-email', [AuthController::class, 'verifyEmail']);
+Route::post('auth/resend-verification', [AuthController::class, 'resendVerification']);
 Route::post('auth/login', [AuthController::class, 'login']);
+Route::post('auth/forgot-password', [AuthController::class, 'forgotPassword']);
+Route::post('auth/reset-password', [AuthController::class, 'resetPassword']);
 
 // Protected routes (require authentication)
 Route::middleware('auth:api')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,12 @@
 <?php
 
+use App\Http\Controllers\AuthController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('app');
 });
+
+Route::get('email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])
+    ->middleware(['signed'])
+    ->name('verification.verify');

--- a/tests/Feature/Auth/ForgotPasswordTest.php
+++ b/tests/Feature/Auth/ForgotPasswordTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\User;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Client;
+use Symfony\Component\HttpFoundation\Response;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Create OAuth clients for Passport
+    Client::create([
+        'id' => 'personal-access-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Personal Access Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['personal_access'],
+        'revoked' => false,
+    ]);
+});
+
+test('user can request a password reset link', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email' => $faker->unique()->safeEmail()]);
+
+    // Act
+    $response = $this->postJson('/api/auth/forgot-password', [
+        'email' => $user->email,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Password reset link sent.',
+        ]);
+});
+
+test('forgot password fails with invalid email', function () {
+    // Act
+    $response = $this->postJson('/api/auth/forgot-password', [
+        'email' => 'not-an-email',
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email']);
+});
+
+test('forgot password fails with non-existent email', function () {
+    // Act
+    $response = $this->postJson('/api/auth/forgot-password', [
+        'email' => 'missing@example.com',
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email']);
+});
+
+test('user can reset password with valid token', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email' => $faker->unique()->safeEmail()]);
+    $token = app('auth.password.broker')->createToken($user);
+    $newPassword = $faker->password(8, 20);
+
+    // Act
+    $response = $this->postJson('/api/auth/reset-password', [
+        'email' => $user->email,
+        'token' => $token,
+        'password' => $newPassword,
+        'password_confirmation' => $newPassword,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Password has been reset.',
+        ]);
+});
+
+test('reset password fails with invalid token', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email' => $faker->unique()->safeEmail()]);
+    $newPassword = $faker->password(8, 20);
+
+    // Act
+    $response = $this->postJson('/api/auth/reset-password', [
+        'email' => $user->email,
+        'token' => 'invalid-token',
+        'password' => $newPassword,
+        'password_confirmation' => $newPassword,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJson([
+            'message' => 'Invalid token or email.',
+        ]);
+});
+
+test('reset password fails with missing fields', function () {
+    // Act
+    $response = $this->postJson('/api/auth/reset-password', []);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email', 'token', 'password']);
+});

--- a/tests/Feature/Auth/VerificationTest.php
+++ b/tests/Feature/Auth/VerificationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use App\Models\User;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\Client;
+use Symfony\Component\HttpFoundation\Response;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Create OAuth clients for Passport
+    Client::create([
+        'id' => 'personal-access-client',
+        'owner_type' => null,
+        'owner_id' => null,
+        'name' => 'Test Personal Access Client',
+        'secret' => 'secret',
+        'provider' => null,
+        'redirect_uris' => ['http://localhost'],
+        'grant_types' => ['personal_access'],
+        'revoked' => false,
+    ]);
+});
+
+test('user can verify email with valid hash', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email_verified_at' => null]);
+    $hash = sha1($user->getEmailForVerification());
+
+    // Act
+    $response = $this->postJson('/api/auth/verify-email', [
+        'id' => $user->id,
+        'hash' => $hash,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Email verified successfully.',
+        ]);
+});
+
+test('verify email fails with invalid hash', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email_verified_at' => null]);
+
+    // Act
+    $response = $this->postJson('/api/auth/verify-email', [
+        'id' => $user->id,
+        'hash' => 'invalid-hash',
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJson([
+            'message' => 'Invalid verification link.',
+        ]);
+});
+
+test('verify email returns already verified', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email_verified_at' => now()]);
+    $hash = sha1($user->getEmailForVerification());
+
+    // Act
+    $response = $this->postJson('/api/auth/verify-email', [
+        'id' => $user->id,
+        'hash' => $hash,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Email already verified.',
+        ]);
+});
+
+test('resend verification email to unverified user', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email_verified_at' => null]);
+
+    // Act
+    $response = $this->postJson('/api/auth/resend-verification', [
+        'email' => $user->email,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Verification email resent.',
+        ]);
+});
+
+test('resend verification returns already verified', function () {
+    // Arrange
+    $faker = Factory::create();
+    $user = User::factory()->create(['email_verified_at' => now()]);
+
+    // Act
+    $response = $this->postJson('/api/auth/resend-verification', [
+        'email' => $user->email,
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_OK)
+        ->assertJson([
+            'message' => 'Email already verified.',
+        ]);
+});
+
+test('resend verification fails with invalid email', function () {
+    // Act
+    $response = $this->postJson('/api/auth/resend-verification', [
+        'email' => 'not-an-email',
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email']);
+});
+
+test('resend verification fails with non-existent email', function () {
+    // Act
+    $response = $this->postJson('/api/auth/resend-verification', [
+        'email' => 'missing@example.com',
+    ]);
+
+    // Assert
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY)
+        ->assertJsonValidationErrors(['email']);
+});


### PR DESCRIPTION
## Summary

This PR implements the forgot password and email verification functionality for the Goal Digger API, completing the authentication system.

## Changes Made

### New Endpoints
- **POST** `/api/auth/forgot-password` - Send password reset link
- **POST** `/api/auth/reset-password` - Reset password with token
- **GET** `/api/auth/verify-email/{id}/{hash}` - Verify email address
- **POST** `/api/auth/resend-verification` - Resend verification email

### Features
- Custom `ResetPasswordNotification` for API-first approach
- Comprehensive validation with proper error messages
- Secure token-based password reset using Laravel's built-in system
- Email verification with hash validation
- Proper HTTP status codes and consistent JSON responses

### Testing
- Comprehensive test coverage for all new endpoints
- Tests for both success and failure scenarios
- Proper validation error testing
- Fixed password reset token generation in tests using official Laravel API

## API Response Examples

### Success (Forgot Password)
```json
{
  "message": "Password reset link sent."
}
```

### Success (Reset Password)
```json
{
  "message": "Password has been reset."
}
```

### Success (Email Verification)
```json
{
  "message": "Email verified successfully."
}
```

### Validation Error
```json
{
  "message": "Validation failed.",
  "errors": {
    "email": ["The email field is required."],
    "password": ["The password field is required."]
  }
}
```

### Error (Invalid Token)
```json
{
  "message": "Invalid token or email."
}
```

## Testing Instructions

Run the following command to test the new authentication endpoints:

```bash
php artisan test tests/Feature/Auth/ForgotPasswordTest.php tests/Feature/Auth/VerificationTest.php
```

Or run all authentication tests:

```bash
php artisan test tests/Feature/Auth/
```

## Breaking Changes

None – all new functionality is additive.

## Dependencies

No new dependencies added.

## Related Issues

Closes ENG-10